### PR TITLE
CF ignore vendor/bundle as we try to stop this error in travis:

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,5 +13,6 @@
 /spec/test_files
 /tags
 /tmp/*
+/vendor/bundle/*
 .env
 .byebug_history


### PR DESCRIPTION
The issue:

Waiting for API to complete processing files...
Job (e9480636-3a3f-4942-afee-803de588499f) failed: The resource file mode is invalid: File mode '444' with path 'vendor/bundle/ruby/2.3.0/cache/bundler/git/waves-utilities-....pack' is invalid. Minimum file mode is '0600'
FAILED