### PR TITLE
Ensure that cancelled and unconfirmed tasks are not `chargeable`

### DIFF
--- a/app/models/submission/task.rb
+++ b/app/models/submission/task.rb
@@ -38,6 +38,8 @@ class Submission::Task < ApplicationRecord
       registration_type) unless registration_type.blank?
   end)
 
+  scope :chargeable, -> { where.not(state: [:initialising, :cancelled]) }
+
   include ActiveModel::Transitions
 
   state_machine auto_scopes: true do

--- a/app/services/account_ledger.rb
+++ b/app/services/account_ledger.rb
@@ -20,7 +20,8 @@ class AccountLedger
   end
 
   def payment_due
-    @payment_due ||= @submission.tasks.map(&:price).inject(:+) || 0
+    @payment_due ||=
+      @submission.tasks.chargeable.map(&:price).inject(:+) || 0
   end
 
   def payment_received

--- a/spec/features/queues/user_views_applications_spec.rb
+++ b/spec/features/queues/user_views_applications_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 feature "User views applications", type: :feature, js: true do
   let!(:submission) do
     submission = create(:submission)
-    create(:task, price: 2500, submission: submission)
+    create(:unclaimed_task, price: 2500, submission: submission)
     submission
   end
 

--- a/spec/services/account_ledger_spec.rb
+++ b/spec/services/account_ledger_spec.rb
@@ -13,14 +13,14 @@ describe AccountLedger do
     end
 
     context "unpaid" do
-      let(:submission) { create(:task).submission }
+      let(:submission) { create(:unclaimed_task).submission }
 
       it { expect(subject).to eq(:unpaid) }
     end
 
     context "paid" do
       let(:submission) do
-        submission = create(:task).submission
+        submission = create(:unclaimed_task).submission
         create(:payment, submission: submission, amount: 2500)
         submission.reload
       end
@@ -29,7 +29,7 @@ describe AccountLedger do
 
     context "part_paid" do
       let(:submission) do
-        submission = create(:task).submission
+        submission = create(:unclaimed_task).submission
         create(:payment, submission: submission, amount: 50)
         submission.reload
       end
@@ -119,10 +119,22 @@ describe AccountLedger do
       it { expect(subject).to eq(0.00) }
     end
 
-    context "with a chargeable task" do
-      let!(:submission) { create(:task).submission }
+    context "with an unclaimed task" do
+      let!(:submission) { create(:unclaimed_task).submission }
 
       it { expect(subject).to eq(2500) }
+
+      context "and a cancelled task" do
+        before { create(:cancelled_task, submission: submission) }
+
+        it { expect(subject).to eq(2500) }
+      end
+
+      context "and an unconfirmed task" do
+        before { create(:task, submission: submission) }
+
+        it { expect(subject).to eq(2500) }
+      end
     end
   end
 
@@ -137,7 +149,7 @@ describe AccountLedger do
 
     context "with a chargeable task and one (over) payment" do
       let!(:submission) do
-        submission = create(:task).submission
+        submission = create(:unclaimed_task).submission
         create(:payment, submission: submission, amount: 2000)
         submission.reload
       end


### PR DESCRIPTION
- This affects the `payment due` calculation