### PR TITLE
Enable 'Export to Excel' as a background job

### DIFF
--- a/app/controllers/admin/reports_controller.rb
+++ b/app/controllers/admin/reports_controller.rb
@@ -25,19 +25,19 @@ class Admin::ReportsController < InternalPagesController
     { vessel: { name: { value: "", result_displayed: "1" } } }
   end
 
-  def build_report
-    @report = Report.build(params[:id], @filter)
-  end
-
   def html_report
     @filter[:page] = params[:page] || 1
     @filter[:per_page] = 50
-    build_report
+
+    @report = Report.build(params[:id], @filter)
   end
 
   def xls_report
-    @filter[:page] = 1
-    @filter[:per_page] = 10000
-    build_report
+    DownloadableReport.delay.build(
+      current_user, Report.build(params[:id], @filter))
+
+    flash[:notice] =
+      "You will shortly receive an email with a link to download the report"
+    redirect_to "/admin/reports/#{params[:id]}?#{request.query_string}"
   end
 end

--- a/app/controllers/admin/reports_controller.rb
+++ b/app/controllers/admin/reports_controller.rb
@@ -33,7 +33,7 @@ class Admin::ReportsController < InternalPagesController
   end
 
   def xls_report
-    DownloadableReport.delay.build(
+    DownloadableReport.delay.build_and_notify(
       current_user, Report.build(params[:id], @filter))
 
     redirect_key = params[:id].gsub("_report", "")

--- a/app/controllers/admin/reports_controller.rb
+++ b/app/controllers/admin/reports_controller.rb
@@ -36,8 +36,10 @@ class Admin::ReportsController < InternalPagesController
     DownloadableReport.delay.build(
       current_user, Report.build(params[:id], @filter))
 
+    redirect_key = params[:id].gsub("_report", "")
+
     flash[:notice] =
       "You will shortly receive an email with a link to download the report"
-    redirect_to "/admin/reports/#{params[:id]}?#{request.query_string}"
+    redirect_to "/admin/reports/#{redirect_key}?#{request.query_string}"
   end
 end

--- a/app/helpers/reports_helper.rb
+++ b/app/helpers/reports_helper.rb
@@ -42,7 +42,7 @@ module ReportsHelper
 
   def render_link_to_download(data_element)
     link_to(
-      "Download",
+      "Download (you will receive an email with a link to download the report)",
       "/admin/reports/#{data_element.report_key}.xls?#{request.query_string}")
   end
 end

--- a/app/mailers/report_mailer.rb
+++ b/app/mailers/report_mailer.rb
@@ -1,0 +1,9 @@
+class ReportMailer < ActionMailer::Base
+  default from: ENV.fetch("EMAIL_FROM")
+
+  def download_link(recipient_email, download_link)
+    @download_link = download_link
+
+    mail(to: recipient_email, subject: "Waves: Report is ready")
+  end
+end

--- a/app/models/downloadable_report.rb
+++ b/app/models/downloadable_report.rb
@@ -1,0 +1,22 @@
+class DownloadableReport < ActiveRecord::Base
+  belongs_to :user
+  has_attached_file :file, validate_media_type: false
+  do_not_validate_attachment_file_type :file
+
+  class << self
+    def build(user, report)
+      create(file: build_file(report), user: user)
+    end
+
+    private
+
+    def build_file(report)
+      FakeFile.new(
+        "#{report.title.parameterize}.xls",
+        ApplicationController.render(
+          template: "admin/reports/show.xls",
+          layout: false,
+          assigns: { report: report }))
+    end
+  end
+end

--- a/app/models/downloadable_report.rb
+++ b/app/models/downloadable_report.rb
@@ -4,8 +4,13 @@ class DownloadableReport < ActiveRecord::Base
   do_not_validate_attachment_file_type :file
 
   class << self
-    def build(user, report)
-      create(file: build_file(report), user: user)
+    def build_and_notify(user, report)
+      downloadable_report = create(file: build_file(report), user: user)
+
+      ReportMailer.download_link(
+        user.email, downloadable_report.download_link).deliver
+
+      downloadable_report
     end
 
     private
@@ -18,5 +23,9 @@ class DownloadableReport < ActiveRecord::Base
           layout: false,
           assigns: { report: report }))
     end
+  end
+
+  def download_link
+    file.expiring_url(10.minutes.since, :original)
   end
 end

--- a/app/models/downloadable_report.rb
+++ b/app/models/downloadable_report.rb
@@ -17,7 +17,7 @@ class DownloadableReport < ActiveRecord::Base
 
     def build_file(report)
       FakeFile.new(
-        "#{report.title.parameterize}.xls",
+        "#{report.title.parameterize}.xlsx",
         ApplicationController.render(
           template: "admin/reports/show.xls",
           layout: false,

--- a/app/services/fake_file.rb
+++ b/app/services/fake_file.rb
@@ -1,0 +1,10 @@
+class FakeFile < StringIO
+  attr_reader :original_filename
+  attr_reader :path
+
+  def initialize(filename, content)
+    super(content)
+    @original_filename = File.basename(filename)
+    @path = File.path(filename)
+  end
+end

--- a/app/views/admin/reports/show.xls.erb
+++ b/app/views/admin/reports/show.xls.erb
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <Workbook xmlns="urn:schemas-microsoft-com:office:spreadsheet"
   xmlns:o="urn:schemas-microsoft-com:office:office"
   xmlns:x="urn:schemas-microsoft-com:office:excel"
@@ -8,7 +8,7 @@
     <Table>
       <% unless @report.xls_title == :hidden %>
         <Row>
-          <Cell ss:ss:MergeAcross="<%= @report.headings.length - 1 %>">
+          <Cell ss:MergeAcross="<%= @report.headings.length - 1 %>">
             <Data ss:Type="String"><%= @report.xls_title %></Data>
           </Cell>
         </Row>
@@ -36,7 +36,7 @@
     <Worksheet ss:Name="<%= @report.second_sheet_title %>">
       <Table>
         <Row>
-          <Cell ss:ss:MergeAcross="<%= @report.headings.length - 1 %>">
+          <Cell ss:MergeAcross="<%= @report.headings.length - 1 %>">
             <Data ss:Type="String"><%= @report.xls_title(@report.second_sheet_title) %></Data>
           </Cell>
         </Row>
@@ -64,7 +64,7 @@
     <Worksheet ss:Name="<%= @report.third_sheet_title %>">
       <Table>
         <Row>
-          <Cell ss:ss:MergeAcross="<%= @report.headings.length - 1 %>">
+          <Cell ss:MergeAcross="<%= @report.headings.length - 1 %>">
             <Data ss:Type="String"><%= @report.xls_title(@report.third_sheet_title) %></Data>
           </Cell>
         </Row>
@@ -92,7 +92,7 @@
     <Worksheet ss:Name="<%= @report.fourth_sheet_title %>">
       <Table>
         <Row>
-          <Cell ss:ss:MergeAcross="<%= @report.headings.length - 1 %>">
+          <Cell ss:MergeAcross="<%= @report.headings.length - 1 %>">
             <Data ss:Type="String"><%= @report.xls_title(@report.fourth_sheet_title) %></Data>
           </Cell>
         </Row>

--- a/app/views/report_mailer/download_link.html.haml
+++ b/app/views/report_mailer/download_link.html.haml
@@ -1,0 +1,5 @@
+%p Here is the link to the report that you requested:
+
+%p= link_to "Download Report", @download_link
+
+%p Please note that this link will expire in 30 minutes.

--- a/app/views/report_mailer/download_link.text.haml
+++ b/app/views/report_mailer/download_link.text.haml
@@ -1,0 +1,5 @@
+Here is the link to the report that you requested from Waves:
+\
+= @download_link
+\
+Please note that this link will expire in 10 minutes.

--- a/db/migrate/20181218135040_create_downloadable_reports.rb
+++ b/db/migrate/20181218135040_create_downloadable_reports.rb
@@ -1,0 +1,12 @@
+class CreateDownloadableReports < ActiveRecord::Migration[5.2]
+  def change
+    create_table :downloadable_reports, id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
+      t.uuid :user_id
+      t.datetime :file_updated_at
+      t.integer :file_file_size
+      t.string :file_content_type
+      t.string :file_file_name
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_12_18_112711) do
+ActiveRecord::Schema.define(version: 2018_12_18_135040) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -181,6 +181,16 @@ ActiveRecord::Schema.define(version: 2018_12_18_112711) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.index ["priority", "run_at"], name: "delayed_jobs_priority"
+  end
+
+  create_table "downloadable_reports", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
+    t.uuid "user_id"
+    t.datetime "file_updated_at"
+    t.integer "file_file_size"
+    t.string "file_content_type"
+    t.string "file_file_name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "engines", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|

--- a/spec/controllers/admin/reports_controller_spec.rb
+++ b/spec/controllers/admin/reports_controller_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+
+describe Admin::ReportsController do
+  context "user exports to excel" do
+    before do
+      sign_in create(:system_manager)
+
+      get :show, params: { id: :cefas, format: :xls }
+    end
+
+    it "redirects to the report page" do
+      expect(response).to redirect_to("/admin/reports/cefas?")
+    end
+
+    it "generates the DownloadableReport", run_delayed_jobs: true do
+      expect(DownloadableReport.last.file_file_name).to eq("cefas.xls")
+    end
+  end
+end
+
+def default_filters
+  { vessel: { name: { value: "", result_displayed: "1" } } }
+end

--- a/spec/controllers/admin/reports_controller_spec.rb
+++ b/spec/controllers/admin/reports_controller_spec.rb
@@ -13,7 +13,7 @@ describe Admin::ReportsController do
     end
 
     it "generates the DownloadableReport", run_delayed_jobs: true do
-      expect(DownloadableReport.last.file_file_name).to eq("cefas.xls")
+      expect(DownloadableReport.last.file_file_name).to eq("cefas.xlsx")
     end
   end
 end

--- a/spec/features/external_reports/user_views_cefas_spec.rb
+++ b/spec/features/external_reports/user_views_cefas_spec.rb
@@ -19,7 +19,7 @@ describe "User views CEFAS reports", js: true, run_delayed_jobs: true do
     expect(page.text).to match("You will shortly receive an email")
 
     expect(DownloadableReport.last.file_file_name)
-      .to eq("open-registrations.xls")
+      .to eq("open-registrations.xlsx")
 
     expect(last_email_sent)
       .to have_subject("Waves: Report is ready")

--- a/spec/features/external_reports/user_views_cefas_spec.rb
+++ b/spec/features/external_reports/user_views_cefas_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe "User views CEFAS reports", js: true do
+describe "User views CEFAS reports", js: true, run_delayed_jobs: true do
   before do
     login_to_reports
     visit admin_report_path(:vessel_age)
@@ -16,7 +16,8 @@ describe "User views CEFAS reports", js: true do
 
     within("#results") { click_on("Download") }
 
-    expect(page.response_headers["Content-Type"]).to match("application/xls")
-    expect(page.text).to match("Worksheet ss:Name=\"Open Registrations\"")
+    expect(page.text).to match("You will shortly receive an email")
+    expect(DownloadableReport.last.file_file_name)
+      .to eq("open-registrations.xls")
   end
 end

--- a/spec/features/external_reports/user_views_cefas_spec.rb
+++ b/spec/features/external_reports/user_views_cefas_spec.rb
@@ -17,7 +17,14 @@ describe "User views CEFAS reports", js: true, run_delayed_jobs: true do
     within("#results") { click_on("Download") }
 
     expect(page.text).to match("You will shortly receive an email")
+
     expect(DownloadableReport.last.file_file_name)
       .to eq("open-registrations.xls")
+
+    expect(last_email_sent)
+      .to have_subject("Waves: Report is ready")
+
+    expect(last_email_sent)
+      .to have_body_text(DownloadableReport.last.download_link)
   end
 end

--- a/spec/features/external_reports/user_views_fishing_regional_spec.rb
+++ b/spec/features/external_reports/user_views_fishing_regional_spec.rb
@@ -18,6 +18,6 @@ describe "User views fishing regional", js: true, run_delayed_jobs: true do
 
     expect(page.text).to match("You will shortly receive an email")
     expect(DownloadableReport.last.file_file_name)
-      .to eq("fishing-regional-report.xls")
+      .to eq("fishing-regional-report.xlsx")
   end
 end

--- a/spec/features/external_reports/user_views_fishing_regional_spec.rb
+++ b/spec/features/external_reports/user_views_fishing_regional_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe "User views fishing regional reports", js: true do
+describe "User views fishing regional", js: true, run_delayed_jobs: true do
   before do
     login_to_reports
     visit admin_report_path(:cefas)
@@ -16,7 +16,8 @@ describe "User views fishing regional reports", js: true do
 
     within("#results") { click_on("Download") }
 
-    expect(page.response_headers["Content-Type"]).to match("application/xls")
-    expect(page.text).to match("Worksheet ss:Name=\"Fishing Regional Report\"")
+    expect(page.text).to match("You will shortly receive an email")
+    expect(DownloadableReport.last.file_file_name)
+      .to eq("fishing-regional-report.xls")
   end
 end

--- a/spec/features/external_reports/user_views_hmrc_spec.rb
+++ b/spec/features/external_reports/user_views_hmrc_spec.rb
@@ -17,6 +17,6 @@ describe "User views HMRC reports", js: true, run_delayed_jobs: true do
     within("#results") { click_on("Download") }
 
     expect(page.text).to match("You will shortly receive an email")
-    expect(DownloadableReport.last.file_file_name).to eq("6-6-99m.xls")
+    expect(DownloadableReport.last.file_file_name).to eq("6-6-99m.xlsx")
   end
 end

--- a/spec/features/external_reports/user_views_hmrc_spec.rb
+++ b/spec/features/external_reports/user_views_hmrc_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe "User views HMRC reports", js: true do
+describe "User views HMRC reports", js: true, run_delayed_jobs: true do
   before do
     login_to_reports
     visit admin_report_path(:vessel_age)
@@ -16,7 +16,7 @@ describe "User views HMRC reports", js: true do
 
     within("#results") { click_on("Download") }
 
-    expect(page.response_headers["Content-Type"]).to match("application/xls")
-    expect(page.text).to match("Worksheet ss:Name=\"6 - 6.99m\"")
+    expect(page.text).to match("You will shortly receive an email")
+    expect(DownloadableReport.last.file_file_name).to eq("6-6-99m.xls")
   end
 end

--- a/spec/features/external_reports/user_views_ihs_spec.rb
+++ b/spec/features/external_reports/user_views_ihs_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe "User views IHS/Fairplay reports", js: true do
+describe "User views IHS/Fairplay reports", js: true, run_delayed_jobs: true do
   before do
     login_to_reports
     visit admin_report_path(:vessel_age)
@@ -11,7 +11,7 @@ describe "User views IHS/Fairplay reports", js: true do
     expect_link_to_export_or_print(false)
     within("#results") { click_on("Download") }
 
-    expect(page.response_headers["Content-Type"]).to match("application/xls")
-    expect(page.text).to match("Worksheet ss:Name=\"IHS Fairplay\"")
+    expect(page.text).to match("You will shortly receive an email")
+    expect(DownloadableReport.last.file_file_name).to eq("ihs-fairplay.xls")
   end
 end

--- a/spec/features/external_reports/user_views_ihs_spec.rb
+++ b/spec/features/external_reports/user_views_ihs_spec.rb
@@ -12,6 +12,6 @@ describe "User views IHS/Fairplay reports", js: true, run_delayed_jobs: true do
     within("#results") { click_on("Download") }
 
     expect(page.text).to match("You will shortly receive an email")
-    expect(DownloadableReport.last.file_file_name).to eq("ihs-fairplay.xls")
+    expect(DownloadableReport.last.file_file_name).to eq("ihs-fairplay.xlsx")
   end
 end

--- a/spec/features/external_reports/user_views_maib_spec.rb
+++ b/spec/features/external_reports/user_views_maib_spec.rb
@@ -20,7 +20,7 @@ describe "User views MAIB reports", js: true, run_delayed_jobs: true do
 
     expect(page.text).to match("You will shortly receive an email")
     expect(DownloadableReport.last.file_file_name)
-      .to eq("fishing-vessel-closures.xls")
+      .to eq("fishing-vessel-closures.xlsx")
   end
 
   scenario "Quarterly Report" do
@@ -32,7 +32,7 @@ describe "User views MAIB reports", js: true, run_delayed_jobs: true do
     within("#results") { click_on("Download") }
 
     expect(page.text).to match("You will shortly receive an email")
-    expect(DownloadableReport.last.file_file_name).to eq("under-12m.xls")
+    expect(DownloadableReport.last.file_file_name).to eq("under-12m.xlsx")
   end
 
   scenario "Vessel Length" do
@@ -45,6 +45,6 @@ describe "User views MAIB reports", js: true, run_delayed_jobs: true do
 
     expect(page.text).to match("You will shortly receive an email")
     expect(DownloadableReport.last.file_file_name)
-      .to eq("fishing-vessel-length.xls")
+      .to eq("fishing-vessel-length.xlsx")
   end
 end

--- a/spec/features/external_reports/user_views_maib_spec.rb
+++ b/spec/features/external_reports/user_views_maib_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe "User views MAIB reports", js: true do
+describe "User views MAIB reports", js: true, run_delayed_jobs: true do
   before do
     login_to_reports
     visit admin_report_path(:fishing_regional)
@@ -18,8 +18,9 @@ describe "User views MAIB reports", js: true do
 
     within("#results") { click_on("Download") }
 
-    expect(page.response_headers["Content-Type"]).to match("application/xls")
-    expect(page.text).to match("Worksheet ss:Name=\"Fishing Vessel Closures\"")
+    expect(page.text).to match("You will shortly receive an email")
+    expect(DownloadableReport.last.file_file_name)
+      .to eq("fishing-vessel-closures.xls")
   end
 
   scenario "Quarterly Report" do
@@ -30,9 +31,8 @@ describe "User views MAIB reports", js: true do
 
     within("#results") { click_on("Download") }
 
-    expect(page.response_headers["Content-Type"]).to match("application/xls")
-    expect(page.text).to match("Worksheet ss:Name=\"Under 12m\"")
-    expect(page.text).to match("Worksheet ss:Name=\"12m and over\"")
+    expect(page.text).to match("You will shortly receive an email")
+    expect(DownloadableReport.last.file_file_name).to eq("under-12m.xls")
   end
 
   scenario "Vessel Length" do
@@ -43,7 +43,8 @@ describe "User views MAIB reports", js: true do
 
     within("#results") { click_on("Download") }
 
-    expect(page.response_headers["Content-Type"]).to match("application/xls")
-    expect(page.text).to match("Worksheet ss:Name=\"Fishing Vessel Length\"")
+    expect(page.text).to match("You will shortly receive an email")
+    expect(DownloadableReport.last.file_file_name)
+      .to eq("fishing-vessel-length.xls")
   end
 end

--- a/spec/features/external_reports/user_views_trinity_house_spec.rb
+++ b/spec/features/external_reports/user_views_trinity_house_spec.rb
@@ -17,6 +17,6 @@ describe "User views Trinity House reports", js: true, run_delayed_jobs: true do
     within("#results") { click_on("Download") }
 
     expect(page.text).to match("You will shortly receive an email")
-    expect(DownloadableReport.last.file_file_name).to eq("part-i.xls")
+    expect(DownloadableReport.last.file_file_name).to eq("part-i.xlsx")
   end
 end

--- a/spec/features/external_reports/user_views_trinity_house_spec.rb
+++ b/spec/features/external_reports/user_views_trinity_house_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe "User views Trinity House reports", js: true do
+describe "User views Trinity House reports", js: true, run_delayed_jobs: true do
   before do
     login_to_reports
     visit admin_report_path(:fishing_regional)
@@ -16,7 +16,7 @@ describe "User views Trinity House reports", js: true do
 
     within("#results") { click_on("Download") }
 
-    expect(page.response_headers["Content-Type"]).to match("application/xls")
-    expect(page.text).to match("Worksheet ss:Name=\"Part I\"")
+    expect(page.text).to match("You will shortly receive an email")
+    expect(DownloadableReport.last.file_file_name).to eq("part-i.xls")
   end
 end

--- a/spec/features/external_reports/user_views_uk_activity_spec.rb
+++ b/spec/features/external_reports/user_views_uk_activity_spec.rb
@@ -26,8 +26,7 @@ describe "User views UK Activity reports", js: true do
 
   scenario "exporting to excel" do
     click_on("Export to Excel")
-    sleep 1
-    expect(page.response_headers["Content-Type"]).to match("application/xls")
-    expect(page.text).to match("UK Activity: 01/01/2017-31/03/2017")
+    expect(page)
+      .to have_css(".alert", text: "You will shortly receive an email")
   end
 end

--- a/spec/features/management_reports/manager_views_staff_performance_by_person_spec.rb
+++ b/spec/features/management_reports/manager_views_staff_performance_by_person_spec.rb
@@ -76,14 +76,6 @@ describe "Manager views staff performance report by person", js: true do
     click_on("Apply Filter")
     dont_expect_result
   end
-
-  scenario "downloading the xls version" do
-    click_on("Export to Excel")
-    sleep 1
-    expect(page.response_headers["Content-Type"]).to match("application/xls")
-    expect(page.text)
-      .to match("Worksheet ss:Name=\"Performance by Member of Staff\"")
-  end
 end
 
 def expect_result

--- a/spec/features/management_reports/manager_views_staff_performance_by_task_spec.rb
+++ b/spec/features/management_reports/manager_views_staff_performance_by_task_spec.rb
@@ -73,14 +73,6 @@ describe "Manager views staff performance report by task", js: true do
     expect(page).to have_css("#results .red", text: 0)
   end
 
-  scenario "downloading the xls version" do
-    click_on("Export to Excel")
-    sleep 1
-    expect(page.response_headers["Content-Type"]).to match("application/xls")
-    expect(page.text)
-      .to match("Worksheet ss:Name=\"Staff Performance by Task\"")
-  end
-
   scenario "viewing the sub report with an existing filter" do
     find("#filter_date_start").set("20/01/2017")
     select("Part III", from: "Part of Register")

--- a/spec/features/management_reports/manager_views_staff_performance_spec.rb
+++ b/spec/features/management_reports/manager_views_staff_performance_spec.rb
@@ -76,7 +76,7 @@ describe "Manager views staff performance report", js: true do
     expect(page)
       .to have_css(".alert", text: "You will shortly receive an email")
     expect(page)
-      .to have_current_path("/admin/reports/staff_performance?")
+      .to have_current_path("/admin/reports/staff_performance")
   end
 
   scenario "viewing the sub report with an existing filter" do

--- a/spec/features/management_reports/manager_views_staff_performance_spec.rb
+++ b/spec/features/management_reports/manager_views_staff_performance_spec.rb
@@ -72,9 +72,11 @@ describe "Manager views staff performance report", js: true do
 
   scenario "downloading the xls version" do
     click_on("Export to Excel")
-    sleep 1
-    expect(page.response_headers["Content-Type"]).to match("application/xls")
-    expect(page.text).to match("Worksheet ss:Name=\"Staff Performance\"")
+
+    expect(page)
+      .to have_css(".alert", text: "You will shortly receive an email")
+    expect(page)
+      .to have_current_path("/admin/reports/staff_performance?")
   end
 
   scenario "viewing the sub report with an existing filter" do

--- a/spec/mailers/previews/report_preview.rb
+++ b/spec/mailers/previews/report_preview.rb
@@ -1,0 +1,7 @@
+# Preview all emails at http://localhost:3000/rails/mailers/notification
+class ReportTemplatesPreview < ActionMailer::Preview
+  def downloadable_report
+    ReportMailer.download_link(
+      "alice@example.com", "http://localhost")
+  end
+end

--- a/spec/models/downloadable_report_spec.rb
+++ b/spec/models/downloadable_report_spec.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+describe DownloadableReport do
+  describe "#build" do
+    let(:user) { create(:user) }
+    let(:report) { Report.build(:cefas) }
+    subject { described_class.build(user, report) }
+
+    it "generates the file" do
+      expect(subject.file.url).to match(%r{.*original\/cefas.xls.*})
+    end
+
+    it "assigns the user" do
+      expect(subject.user).to eq(user)
+    end
+  end
+end

--- a/spec/models/downloadable_report_spec.rb
+++ b/spec/models/downloadable_report_spec.rb
@@ -1,10 +1,11 @@
 require "rails_helper"
 
 describe DownloadableReport do
-  describe "#build" do
-    let(:user) { create(:user) }
-    let(:report) { Report.build(:cefas) }
-    subject { described_class.build(user, report) }
+  describe "#build_and_notify" do
+    let!(:user) { create(:user) }
+    let!(:report) { Report.build(:cefas) }
+
+    subject { described_class.build_and_notify(user, report) }
 
     it "generates the file" do
       expect(subject.file.url).to match(%r{.*original\/cefas.xls.*})

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -22,6 +22,12 @@ RSpec.configure do |config|
   config.use_transactional_fixtures = false
   config.include Devise::Test::ControllerHelpers, type: :controller
   config.include Devise::Test::IntegrationHelpers, type: :feature
+
+  config.around(:each, :run_delayed_jobs) do |example|
+    Delayed::Worker.delay_jobs = false
+    example.run
+    Delayed::Worker.delay_jobs = true
+  end
 end
 
 ActiveRecord::Migration.maintain_test_schema!


### PR DESCRIPTION
Reports need to be run in a background job as the xls files are too large to be generated in the http request.

- [x] Save report output to XLS file `DownloadableReport`
- [x] Update controller to send report processing to background task
- [x] Update view to render 'You will shortly receive a link to download the file'
- [x] Email user with a link to download the file
- [x] Resolve xls mime type issue when file is upload (paperclip) This was due to an error in xml syntax

Relates to:
https://trello.com/c/4iTzWok3/39-reports
 