### PR TITLE
Bootstrap-sass security update

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem "auto_increment"
 gem "active_model_serializers"
 gem "bootstrap-datepicker-rails"
 gem "bootstrap-multiselect-rails"
-gem "bootstrap-sass", "~> 3.3.6"
+gem "bootstrap-sass", "~> 3.4.1"
 gem "bootstrap3-datetimepicker-rails"
 gem "business_time"
 gem "clockwork", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -98,7 +98,7 @@ GEM
     auto_increment (1.5.0)
       activerecord (>= 4.0, < 5.3)
       activesupport (>= 4.0, < 5.3)
-    autoprefixer-rails (9.1.0)
+    autoprefixer-rails (9.4.9)
       execjs
     awesome_print (1.8.0)
     azure (0.7.10)
@@ -125,9 +125,9 @@ GEM
       railties (>= 3.0)
     bootstrap-multiselect-rails (0.9.9)
       rails (>= 4.0.0)
-    bootstrap-sass (3.3.7)
+    bootstrap-sass (3.4.1)
       autoprefixer-rails (>= 5.2.1)
-      sass (>= 3.3.4)
+      sassc (>= 2.0.0)
     bootstrap3-datetimepicker-rails (4.17.47)
       momentjs-rails (>= 2.8.1)
     brakeman (4.3.1)
@@ -469,6 +469,9 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
+    sassc (2.0.0)
+      ffi (~> 1.9.6)
+      rake
     select2-rails (4.0.3)
       thor (~> 0.14)
     sentry-raven (2.7.4)
@@ -567,7 +570,7 @@ DEPENDENCIES
   awesome_print
   bootstrap-datepicker-rails
   bootstrap-multiselect-rails
-  bootstrap-sass (~> 3.3.6)
+  bootstrap-sass (~> 3.4.1)
   bootstrap3-datetimepicker-rails
   brakeman
   bullet


### PR DESCRIPTION
CVE-2019-8331 More information
moderate severity
Vulnerable versions: >= 3.0.0, < 3.4.1
Patched version: 3.4.1
In Bootstrap 4 before 4.3.1 and Bootstrap 3 before 3.4.1, XSS is possible in the tooltip or popover data-template attribute. For more information, see: https://blog.getbootstrap.com/2019/02/13/bootstrap-4-3-1-and-3-4-1/