### PR TITLE
Preserve closure state when recording transcript event

### DIFF
--- a/app/models/builders/registration_builder.rb
+++ b/app/models/builders/registration_builder.rb
@@ -1,16 +1,16 @@
 class Builders::RegistrationBuilder
   class << self
-    def create(task, registered_vessel, starts_at, ends_at, provisional)
+    def create(task, vessel, starts_at, ends_at, closed_at, provisional)
       registration = Registration.create(
-        vessel_id: registered_vessel.id,
+        vessel_id: vessel.id,
         registered_at: registered_at(task, starts_at),
         registered_until: registered_until(task, ends_at),
-        registry_info: registered_vessel.registry_info,
-        actioned_by: task.claimant,
-        provisional: provisional)
+        closed_at: closed_at,
+        registry_info: vessel.registry_info,
+        actioned_by: task.claimant, provisional: provisional)
 
       task.submission.update_attributes(registration: registration)
-      registered_vessel.update_attributes(current_registration: registration)
+      vessel.update_attributes(current_registration: registration)
 
       registration
     end

--- a/app/services/application_processor.rb
+++ b/app/services/application_processor.rb
@@ -44,6 +44,7 @@ class ApplicationProcessor
           @registered_vessel,
           @approval_params[:registration_starts_at],
           @approval_params[:registration_ends_at],
+          nil,
           provisional)
     end
 
@@ -56,6 +57,7 @@ class ApplicationProcessor
           @registered_vessel,
           @registered_vessel.current_registration.registered_at,
           @registered_vessel.current_registration.registered_until,
+          @registered_vessel.current_registration.closed_at,
           @registered_vessel.current_registration.provisional?)
     end
 

--- a/spec/models/builders/registration_builder_spec.rb
+++ b/spec/models/builders/registration_builder_spec.rb
@@ -16,6 +16,7 @@ describe Builders::RegistrationBuilder do
           registered_vessel,
           "10/10/2012 12:23 PM".to_datetime,
           "10/10/2017 12:23 PM".to_datetime,
+          nil,
           false)
       end
 
@@ -56,15 +57,30 @@ describe Builders::RegistrationBuilder do
           registered_vessel,
           "10/10/2012 12:23 PM".to_datetime,
           "10/10/2017 12:23 PM".to_datetime,
+          nil,
           true)
       end
 
       it { expect(subject).to be_provisional }
     end
 
+    context "with the closed_at parameter" do
+      subject do
+        described_class.create(
+          task,
+          registered_vessel,
+          "10/10/2012 12:23 PM".to_datetime,
+          "10/10/2017 12:23 PM".to_datetime,
+          "10/10/2017 12:23 PM".to_datetime,
+          true)
+      end
+
+      it { expect(subject.closed_at).to eq("10/10/2017 12:23 PM") }
+    end
+
     context "when the dates are blank" do
       subject do
-        described_class.create(task, registered_vessel, "", nil, false)
+        described_class.create(task, registered_vessel, "", nil, nil, false)
       end
 
       it { expect(subject).to be_persisted }

--- a/spec/services/application_processor_spec.rb
+++ b/spec/services/application_processor_spec.rb
@@ -46,7 +46,7 @@ describe ApplicationProcessor do
           .to receive(:create)
           .with(
             task,
-            registered_vessel, "01/01/2011", "01/01/2016", false)
+            registered_vessel, "01/01/2011", "01/01/2016", nil, false)
       end
 
       it { subject }
@@ -67,7 +67,7 @@ describe ApplicationProcessor do
           .to receive(:create)
           .with(
             task,
-            registered_vessel, "01/01/2011", "01/04/2011", true)
+            registered_vessel, "01/01/2011", "01/04/2011", nil, true)
       end
 
       it { subject }
@@ -84,6 +84,7 @@ describe ApplicationProcessor do
             submission.registered_vessel,
             registered_vessel.current_registration.registered_at,
             registered_vessel.current_registration.registered_until,
+            registered_vessel.current_registration.closed_at,
             registered_vessel.current_registration.provisional?)
       end
 


### PR DESCRIPTION
- If a vessel's registration is closed, then that state should be
preserved when recording a transcript event

- This was raised with reference to discharging a mortgage
but should apply to any event